### PR TITLE
Fix build with modern cmake and protobuf/abseil releases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.30)
 project(mumlib)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
 add_definitions(-DOPT_TLS_OPENSSL)
 if (MSYS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc -static")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,16 +1,18 @@
 cmake_minimum_required(VERSION 3.30)
 project(mumlib)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-add_definitions(-DOPT_TLS_OPENSSL)
+# this could still be improved a lot by making more definitions and properties target specific
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED True)
+
+add_definitions(-DOPT_TLS_OPENSSL) # TODO: what is this for? can't find any ifdef for this anywhere
 if (MSYS)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc -static")
   add_definitions(-DLOG4CPP_FIX_ERROR_COLLISION=1 -D__USE_W32_SOCKETS)
 elseif (NOT APPLE)
   add_definitions(-D_POSIX_C_SOURCE=200112L)
 endif()
-
-
 if (APPLE)
     link_directories(/opt/homebrew/lib) # Include the default homebrew library directory
 endif()
@@ -19,6 +21,8 @@ find_package(PkgConfig REQUIRED)
 
 if (NOT MSYS)
 find_package(Boost REQUIRED)
+else()
+include_directories(~/boost_1_72_0)
 endif()
 
 find_package(OpenSSL REQUIRED)
@@ -29,14 +33,8 @@ pkg_check_modules(Speex "speex" REQUIRED IMPORTED_TARGET)
 pkg_check_modules(SpeexDSP "speexdsp" REQUIRED IMPORTED_TARGET)
 pkg_check_modules(Opus "opus" REQUIRED IMPORTED_TARGET)
 
-if (MSYS)
-include_directories(~/boost_1_72_0)
-elseif (NOT APPLE)
-INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
-endif()
 
-include_directories(${CMAKE_CURRENT_BINARY_DIR}) # protobuf
-include_directories(include)
+include_directories(${CMAKE_CURRENT_BINARY_DIR}) # needed for protobuf output, idk
 
 set(MUMLIB_PUBLIC_HEADERS include/mumlib.hpp include/mumlib/VarInt.hpp)
 
@@ -55,10 +53,6 @@ set(MUMLIB_SRC
         src/VarInt.cpp
         src/Transport.cpp
         src/Audio.cpp
-        )
-
-set(SPEEX_LIBRARIES
-        speexdsp
         )
 
 add_library(mumlib STATIC ${MUMLIB_SRC} ${MUMLIB_PUBLIC_HEADERS} ${MUMLIB_PRIVATE_HEADERS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(mumlib)
 
 if (MSYS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,11 +73,13 @@ endif ()
 set_target_properties(mumlib PROPERTIES PUBLIC_HEADER "${MUMLIB_PUBLIC_HEADERS}")
 
 add_executable(mumlib_example mumlib_example.cpp)
-
+target_link_libraries(mumlib_example mumlib PkgConfig::LOG4CPP)
 if (MSYS)
-target_link_libraries(mumlib_example mumlib ws2_32)
-else ()
-target_link_libraries(mumlib_example mumlib)
+target_link_libraries(mumlib_example ws2_32)
 endif ()
+
+if (APPLE)
+    target_include_directories(mumlib_example PRIVATE /opt/homebrew/include)
+endif()
 
 install(TARGETS DESTINATION mumlib LIBRARY DESTINATION lib PUBLIC_HEADER DESTINATION include/mumlib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,10 +2,10 @@ cmake_minimum_required(VERSION 3.5)
 project(mumlib)
 
 if (MSYS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3 -DLOG4CPP_FIX_ERROR_COLLISION=1 -D__USE_W32_SOCKETS -static-libstdc++ -static-libgcc -static")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3 -DLOG4CPP_FIX_ERROR_COLLISION=1 -D__USE_W32_SOCKETS -static-libstdc++ -static-libgcc -static")
   add_definitions(-DOPT_TLS_OPENSSL)
 elseif (NOT APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -O3")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
   add_definitions(-DOPT_TLS_OPENSSL -D_POSIX_C_SOURCE=200112L)
 elseif()
   LINK_DIRECTORIES(/opt/local/lib) # Include the default MacPorts library directory

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,11 +35,7 @@ elseif (NOT APPLE)
 INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
 endif()
 
-include_directories(${OPENSSL_INCLUDE_DIRS})
-#include_directories(${PROTOBUF_INCLUDE_DIRS})
-include_directories(${OPUS_INCLUDE_DIRS})
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-include_directories(${LOG4CPP_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_BINARY_DIR}) # protobuf
 include_directories(include)
 
 set(MUMLIB_PUBLIC_HEADERS include/mumlib.hpp include/mumlib/VarInt.hpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,19 +71,13 @@ target_include_directories(mumlib PUBLIC include)
 protobuf_generate(TARGET mumlib PROTOS Mumble.proto)
 
 target_link_libraries(mumlib INTERFACE ${Boost_LIBRARIES})
-if (MSYS)
-target_link_libraries(mumlib PRIVATE
-        PkgConfig::Speex PkgConfig::SpeexDSP PkgConfig::Opus
-        OpenSSL::SSL OpenSSL::Crypto
-        PkgConfig::LOG4CPP
-        ws2_32 winmm z)
-target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)
-else ()
 target_link_libraries(mumlib PRIVATE
         PkgConfig::Speex PkgConfig::SpeexDSP PkgConfig::Opus
         OpenSSL::SSL OpenSSL::Crypto
         PkgConfig::LOG4CPP)
-    target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)
+target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)
+if (MSYS)
+target_link_libraries(mumlib PRIVATE ws2_32 winmm z)
 endif ()
 
 set_target_properties(mumlib PROPERTIES PUBLIC_HEADER "${MUMLIB_PUBLIC_HEADERS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.0)
+cmake_minimum_required(VERSION 3.5)
 project(mumlib)
 
 if (MSYS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ find_package(Protobuf CONFIG REQUIRED)
 
 pkg_check_modules(LOG4CPP "log4cpp" REQUIRED IMPORTED_TARGET)
 pkg_check_modules(Speex "speex" REQUIRED IMPORTED_TARGET)
+pkg_check_modules(SpeexDSP "speexdsp" REQUIRED IMPORTED_TARGET)
 pkg_check_modules(Opus "opus" REQUIRED IMPORTED_TARGET)
 
 if (MSYS)
@@ -68,14 +69,14 @@ protobuf_generate(TARGET mumlib PROTOS Mumble.proto)
 target_link_libraries(mumlib INTERFACE ${Boost_LIBRARIES})
 if (MSYS)
 target_link_libraries(mumlib PRIVATE
-        PkgConfig::Speex PkgConfig::Opus
+        PkgConfig::Speex PkgConfig::SpeexDSP PkgConfig::Opus
         OpenSSL::SSL OpenSSL::Crypto
         PkgConfig::LOG4CPP
         ws2_32 winmm z)
 target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)
 else ()
 target_link_libraries(mumlib PRIVATE
-        PkgConfig::Speex PkgConfig::Opus
+        PkgConfig::Speex PkgConfig::SpeexDSP PkgConfig::Opus
         OpenSSL::SSL OpenSSL::Crypto
         PkgConfig::LOG4CPP)
     target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,18 @@
 cmake_minimum_required(VERSION 3.30)
 project(mumlib)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
+add_definitions(-DOPT_TLS_OPENSSL)
 if (MSYS)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3 -DLOG4CPP_FIX_ERROR_COLLISION=1 -D__USE_W32_SOCKETS -static-libstdc++ -static-libgcc -static")
-  add_definitions(-DOPT_TLS_OPENSSL)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc -static")
+  add_definitions(-DLOG4CPP_FIX_ERROR_COLLISION=1 -D__USE_W32_SOCKETS)
 elseif (NOT APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
-  add_definitions(-DOPT_TLS_OPENSSL -D_POSIX_C_SOURCE=200112L)
-else()
-  LINK_DIRECTORIES(/opt/homebrew/lib) # Include the default homebrew library directory
+  add_definitions(-D_POSIX_C_SOURCE=200112L)
+endif()
+
+
+if (APPLE)
+    link_directories(/opt/homebrew/lib) # Include the default homebrew library directory
 endif()
 
 find_package(PkgConfig REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.30)
 project(mumlib)
 
 if (MSYS)
@@ -7,22 +7,22 @@ if (MSYS)
 elseif (NOT APPLE)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17 -O3")
   add_definitions(-DOPT_TLS_OPENSSL -D_POSIX_C_SOURCE=200112L)
-elseif()
-  LINK_DIRECTORIES(/opt/local/lib) # Include the default MacPorts library directory
+else()
+  LINK_DIRECTORIES(/opt/homebrew/lib) # Include the default homebrew library directory
 endif()
 
-INCLUDE(FindPkgConfig)
 find_package(PkgConfig REQUIRED)
 
 if (NOT MSYS)
-find_package(Boost COMPONENTS system REQUIRED)
+find_package(Boost REQUIRED)
 endif()
 
 find_package(OpenSSL REQUIRED)
-find_package(Protobuf REQUIRED)
+find_package(Protobuf CONFIG REQUIRED)
 
-pkg_check_modules(LOG4CPP "log4cpp")
-pkg_check_modules(OPUS "opus")
+pkg_check_modules(LOG4CPP "log4cpp" REQUIRED IMPORTED_TARGET)
+pkg_check_modules(Speex "speex" REQUIRED IMPORTED_TARGET)
+pkg_check_modules(Opus "opus" REQUIRED IMPORTED_TARGET)
 
 if (MSYS)
 include_directories(~/boost_1_72_0)
@@ -30,8 +30,8 @@ elseif (NOT APPLE)
 INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
 endif()
 
-include_directories(${OPENSSL_INCLUDE_DIR})
-include_directories(${PROTOBUF_INCLUDE_DIRS})
+include_directories(${OPENSSL_INCLUDE_DIRS})
+#include_directories(${PROTOBUF_INCLUDE_DIRS})
 include_directories(${OPUS_INCLUDE_DIRS})
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 include_directories(${LOG4CPP_INCLUDE_DIRS})
@@ -60,25 +60,25 @@ set(SPEEX_LIBRARIES
         speexdsp
         )
 
-PROTOBUF_GENERATE_CPP(PROTO_SRCS PROTO_HDRS Mumble.proto)
+add_library(mumlib STATIC ${MUMLIB_SRC} ${MUMLIB_PUBLIC_HEADERS} ${MUMLIB_PRIVATE_HEADERS})
+target_include_directories(mumlib PUBLIC include)
 
-add_library(mumlib STATIC ${MUMLIB_SRC} ${MUMLIB_PUBLIC_HEADERS} ${MUMLIB_PRIVATE_HEADERS} ${PROTO_SRCS} ${PROTO_HDRS})
+protobuf_generate(TARGET mumlib PROTOS Mumble.proto)
 
+target_link_libraries(mumlib INTERFACE ${Boost_LIBRARIES})
 if (MSYS)
-target_link_libraries(mumlib
-        ${SPEEX_LIBRARIES}
-        ${PROTOBUF_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
-        ${LOG4CPP_LIBRARIES}
-        ${OPUS_LIBRARIES} ws2_32 winmm z crypto ssl)
+target_link_libraries(mumlib PRIVATE
+        PkgConfig::Speex PkgConfig::Opus
+        OpenSSL::SSL OpenSSL::Crypto
+        PkgConfig::LOG4CPP
+        ws2_32 winmm z)
+target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)
 else ()
-target_link_libraries(mumlib
-        ${SPEEX_LIBRARIES}
-        ${PROTOBUF_LIBRARIES}
-        ${OPENSSL_LIBRARIES}
-        ${LOG4CPP_LIBRARIES}
-        ${OPUS_LIBRARIES}
-        ${Boost_LIBRARIES})
+target_link_libraries(mumlib PRIVATE
+        PkgConfig::Speex PkgConfig::Opus
+        OpenSSL::SSL OpenSSL::Crypto
+        PkgConfig::LOG4CPP)
+    target_link_libraries(mumlib PRIVATE protobuf::libprotobuf)
 endif ()
 
 set_target_properties(mumlib PROPERTIES PUBLIC_HEADER "${MUMLIB_PUBLIC_HEADERS}")

--- a/include/mumlib.hpp
+++ b/include/mumlib.hpp
@@ -53,11 +53,11 @@ namespace mumlib {
     public:
         explicit Mumlib(Callback &callback);
 
-        Mumlib(Callback &callback, io_service &ioService);
+        Mumlib(Callback &callback, io_context &ioService);
 
         Mumlib(Callback &callback, MumlibConfiguration &configuration);
 
-        Mumlib(Callback &callback, io_service &ioService, MumlibConfiguration &configuration);
+        Mumlib(Callback &callback, io_context &ioService, MumlibConfiguration &configuration);
 
         virtual ~Mumlib();
 

--- a/include/mumlib/Transport.hpp
+++ b/include/mumlib/Transport.hpp
@@ -7,7 +7,6 @@
 #include <boost/noncopyable.hpp>
 #include <boost/asio/ssl.hpp>
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <boost/pool/pool.hpp>
 
 #include <log4cpp/Category.hh>

--- a/include/mumlib/Transport.hpp
+++ b/include/mumlib/Transport.hpp
@@ -42,7 +42,7 @@ namespace mumlib {
     class SslContextHelper : boost::noncopyable {
         public:
             SslContextHelper(boost::asio::ssl::context &ctx,
-                    std::string cert_file, std::string privkey_file);
+                    std::string cert_file_path, std::string privkey_file_path);
             ~SslContextHelper() { };
     };
 
@@ -128,7 +128,7 @@ namespace mumlib {
 
         void doReceiveSsl();
 
-        void sendSsl(uint8_t *buff, int length);
+        void sendSsl(uint8_t *buff, size_t length);
 
         void sendSslAsync(uint8_t *buff, int length);
 

--- a/include/mumlib/Transport.hpp
+++ b/include/mumlib/Transport.hpp
@@ -48,7 +48,7 @@ namespace mumlib {
 
     class Transport : boost::noncopyable {
     public:
-        Transport(io_service &ioService,
+        Transport(io_context &ioService,
                   ProcessControlMessageFunction processControlMessageFunc,
                   ProcessEncodedAudioPacketFunction processEncodedAudioPacketFunction,
                   bool noUdp = false,
@@ -84,7 +84,7 @@ namespace mumlib {
     private:
         log4cpp::Category &logger;
 
-        io_service &ioService;
+        io_context &ioService;
 
         pair<string, int> connectionParams;
 
@@ -115,7 +115,7 @@ namespace mumlib {
         ssl::stream<tcp::socket> sslSocket;
         uint8_t *sslIncomingBuffer;
 
-        deadline_timer pingTimer;
+        boost::asio::system_timer pingTimer;
         std::chrono::time_point<std::chrono::system_clock> lastReceivedUdpPacketTimestamp;
 
         boost::pool<> asyncBufferPool;

--- a/include/mumlib/Transport.hpp
+++ b/include/mumlib/Transport.hpp
@@ -105,7 +105,7 @@ namespace mumlib {
         PingState ping_state;
 
         udp::socket udpSocket;
-        ip::udp::endpoint udpReceiverEndpoint;
+        udp::endpoint udpReceiverEndpoint;
         uint8_t udpIncomingBuffer[MAX_UDP_LENGTH];
         CryptState cryptState;
 

--- a/src/Audio.cpp
+++ b/src/Audio.cpp
@@ -2,7 +2,7 @@
 
 #include <boost/format.hpp>
 
-static boost::posix_time::seconds RESET_SEQUENCE_NUMBER_INTERVAL(2);
+static std::chrono::seconds RESET_SEQUENCE_NUMBER_INTERVAL(2);
 
 namespace {
 
@@ -282,7 +282,7 @@ int mumlib::Audio::encodeAudioPacket(int target, int16_t *inputPcmBuffer, int in
     const int lastAudioPacketSentInterval = duration_cast<milliseconds>(
             system_clock::now() - lastEncodedAudioPacketTimestamp).count();
 
-    if (lastAudioPacketSentInterval > RESET_SEQUENCE_NUMBER_INTERVAL.total_milliseconds() + 1000) {
+    if (lastAudioPacketSentInterval > duration_cast<milliseconds>(RESET_SEQUENCE_NUMBER_INTERVAL + seconds(1)).count()) {
         logger.notice("Last audio packet was sent %d ms ago, resetting encoder.", lastAudioPacketSentInterval);
         resetEncoder();
     }

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -12,6 +12,7 @@
 #include <thread>
 
 using namespace std;
+using namespace std::placeholders;
 
 static chrono::seconds PING_INTERVAL(4);
 
@@ -55,7 +56,7 @@ mumlib::Transport::Transport(
 
     sslIncomingBuffer = new uint8_t[MAX_TCP_LENGTH];
 
-    pingTimer.async_wait(boost::bind(&Transport::pingTimerTick, this, _1));
+    pingTimer.async_wait(std::bind(&Transport::pingTimerTick, this, _1));
 }
 
 mumlib::Transport::~Transport() {
@@ -244,7 +245,7 @@ void mumlib::Transport::doReceiveUdp()
 void mumlib::Transport::sslConnectHandler(const boost::system::error_code &error) {
     if (!error) {
         sslSocket.async_handshake(ssl::stream_base::client,
-                                  boost::bind(&Transport::sslHandshakeHandler, this,
+                                  std::bind(&Transport::sslHandshakeHandler, this,
                                               boost::asio::placeholders::error));
     }
     else {
@@ -295,7 +296,7 @@ void mumlib::Transport::pingTimerTick(const boost::system::error_code &e) {
 
     logger.warn("TimerTick!.");
     pingTimer.expires_after(PING_INTERVAL);
-    pingTimer.async_wait(boost::bind(&Transport::pingTimerTick, this, _1));
+    pingTimer.async_wait(std::bind(&Transport::pingTimerTick, this, _1));
 }
 
 void mumlib::Transport::sendUdpAsync(uint8_t *buff, int length) {

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -112,7 +112,7 @@ void mumlib::Transport::connect(
         logger.warn("resolverTcp");
 
         async_connect(sslSocket.lowest_layer(), resolverTcp.resolve(host, to_string(port)),
-            bind(&Transport::sslConnectHandler, this, boost::asio::placeholders::error));
+            [this](auto err, const auto&) { sslConnectHandler(err); });
         logger.warn("async_connect try");
     } catch (runtime_error &exp) {
         throwTransportException(string("failed to establish connection: ") + exp.what());
@@ -137,10 +137,10 @@ void mumlib::Transport::disconnect()
         }
 
         state = ConnectionState::NOT_CONNECTED;
-        printf("Not Connected\n");
+        logger.info("Not Connected\n");
     }
 
-    printf("Disconnected\n");
+    logger.info("Disconnected\n");
     std::this_thread::sleep_for(std::chrono::seconds(3));
 }
 
@@ -245,10 +245,10 @@ void mumlib::Transport::doReceiveUdp()
 void mumlib::Transport::sslConnectHandler(const boost::system::error_code &error) {
     if (!error) {
         sslSocket.async_handshake(ssl::stream_base::client,
-                                  std::bind(&Transport::sslHandshakeHandler, this,
-                                              boost::asio::placeholders::error));
+                                  [this](auto& err) { sslHandshakeHandler(err); });
     }
     else {
+        logger.warn("boost error: %s", error.to_string().c_str());
         disconnect();
     }
 }
@@ -296,7 +296,7 @@ void mumlib::Transport::pingTimerTick(const boost::system::error_code &e) {
 
     logger.warn("TimerTick!.");
     pingTimer.expires_after(PING_INTERVAL);
-    pingTimer.async_wait(std::bind(&Transport::pingTimerTick, this, _1));
+    pingTimer.async_wait([this](auto err) { this->pingTimerTick(err); });
 }
 
 void mumlib::Transport::sendUdpAsync(uint8_t *buff, int length) {
@@ -611,8 +611,7 @@ void mumlib::Transport::sendEncodedAudioPacket(uint8_t *buffer, int length) {
 }
 
 void mumlib::Transport::processAudioPacket(uint8_t *buff, int length) {
-    auto type = static_cast<AudioPacketType >((buff[0] & 0xE0) >> 5);
-    switch (type) {
+    switch (auto type = static_cast<AudioPacketType >((buff[0] & 0xE0) >> 5)) {
         case AudioPacketType::CELT_Alpha:
         case AudioPacketType::Speex:
         case AudioPacketType::CELT_Beta:

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -13,7 +13,7 @@
 
 using namespace std;
 
-static boost::posix_time::seconds PING_INTERVAL(4);
+static chrono::seconds PING_INTERVAL(4);
 
 const long CLIENT_VERSION = 0x01020A;
 const string CLIENT_RELEASE("Mumlib");
@@ -33,7 +33,7 @@ static map<MumbleProto::Reject_RejectType, string> rejectMessages = {
 };
 
 mumlib::Transport::Transport(
-        io_service &ioService,
+        io_context &ioService,
         mumlib::ProcessControlMessageFunction processMessageFunc,
         ProcessEncodedAudioPacketFunction processEncodedAudioPacketFunction,
         bool noUdp,
@@ -92,8 +92,10 @@ void mumlib::Transport::connect(
     try {
         if (not noUdp) {
             ip::udp::resolver resolverUdp(ioService);
-            ip::udp::resolver::query queryUdp(ip::udp::v4(), host, to_string(port));
-            udpReceiverEndpoint = *resolverUdp.resolve(queryUdp);
+            for (const auto& entry: resolverUdp.resolve(ip::udp::v4(), host, to_string(port))) {
+                udpReceiverEndpoint = entry;
+                break;
+            }
             udpSocket.open(ip::udp::v4());
 
             boost::array<char, 1> send_buf  = { 0 };
@@ -107,11 +109,9 @@ void mumlib::Transport::connect(
 
         ip::tcp::resolver resolverTcp(ioService);
         logger.warn("resolverTcp");
-        ip::tcp::resolver::query queryTcp(host, to_string(port));
-        logger.warn("queryTcp");
 
-        async_connect(sslSocket.lowest_layer(), resolverTcp.resolve(queryTcp),
-                      bind(&Transport::sslConnectHandler, this, boost::asio::placeholders::error));
+        async_connect(sslSocket.lowest_layer(), resolverTcp.resolve(host, to_string(port)),
+            bind(&Transport::sslConnectHandler, this, boost::asio::placeholders::error));
         logger.warn("async_connect try");
     } catch (runtime_error &exp) {
         throwTransportException(string("failed to establish connection: ") + exp.what());
@@ -281,7 +281,7 @@ void mumlib::Transport::pingTimerTick(const boost::system::error_code &e) {
                 const int lastUdpReceivedMilliseconds = duration_cast<milliseconds>(
                         system_clock::now() - lastReceivedUdpPacketTimestamp).count();
 
-                if (lastUdpReceivedMilliseconds > PING_INTERVAL.total_milliseconds() + 1000) {
+                if (lastUdpReceivedMilliseconds > duration_cast<milliseconds>(PING_INTERVAL + seconds(1)).count()) {
                     logger.warn("Didn't receive UDP ping in %d ms, falling back to TCP.", lastUdpReceivedMilliseconds);
                 }
             }
@@ -294,7 +294,7 @@ void mumlib::Transport::pingTimerTick(const boost::system::error_code &e) {
     }
 
     logger.warn("TimerTick!.");
-    pingTimer.expires_at(pingTimer.expires_at() + PING_INTERVAL);
+    pingTimer.expires_after(PING_INTERVAL);
     pingTimer.async_wait(boost::bind(&Transport::pingTimerTick, this, _1));
 }
 

--- a/src/Transport.cpp
+++ b/src/Transport.cpp
@@ -383,7 +383,8 @@ void mumlib::Transport::processMessageInternal(MessageType messageType, uint8_t 
             break;
         case MessageType::PING: {
             MumbleProto::Ping ping;
-            ping.ParseFromArray(buffer, length);
+            if (!ping.ParseFromArray(buffer, length))
+                goto malformed;
             stringstream log;
             log << "Received ping.";
             if (ping.has_good()) {
@@ -408,7 +409,8 @@ void mumlib::Transport::processMessageInternal(MessageType messageType, uint8_t 
             break;
         case MessageType::REJECT: {
             MumbleProto::Reject reject;
-            reject.ParseFromArray(buffer, length);
+            if (!reject.ParseFromArray(buffer, length))
+                goto malformed;
 
             stringstream errorMesg;
             errorMesg << "failed to authenticate";
@@ -435,7 +437,8 @@ void mumlib::Transport::processMessageInternal(MessageType messageType, uint8_t 
         case MessageType::CRYPTSETUP: {
             if (not noUdp) {
                 MumbleProto::CryptSetup cryptsetup;
-                cryptsetup.ParseFromArray(buffer, length);
+                if (!cryptsetup.ParseFromArray(buffer, length))
+                    goto malformed;
 
                 if (cryptsetup.client_nonce().length() != AES_BLOCK_SIZE
                     or cryptsetup.server_nonce().length() != AES_BLOCK_SIZE
@@ -467,6 +470,11 @@ void mumlib::Transport::processMessageInternal(MessageType messageType, uint8_t 
         }
             break;
     }
+
+    return;
+
+malformed:
+    logger.warn("Malformed message, type = %d.", messageType);
 }
 
 void mumlib::Transport::sendUdpPing()
@@ -482,8 +490,7 @@ void mumlib::Transport::sendUdpPing()
     sendUdpAsync(&message[0], static_cast<int>(message.size()));
 }
 
-void mumlib::Transport::sendSsl(uint8_t *buff, int length) {
-
+void mumlib::Transport::sendSsl(uint8_t *buff, size_t length) {
     if (length > MAX_TCP_LENGTH) {
         logger.warn("Sending %d B of data via SSL. Maximal allowed data length to receive is %d B.", length,
                     MAX_TCP_LENGTH);
@@ -496,7 +503,7 @@ void mumlib::Transport::sendSsl(uint8_t *buff, int length) {
     }
 
     try {
-        write(sslSocket, boost::asio::buffer(buff, static_cast<size_t>(length)));
+        write(sslSocket, buffer(buff, length));
     } catch (boost::system::system_error &err) {
         throwTransportException(std::string("SSL send failed: ") + err.what());
     }
@@ -516,7 +523,7 @@ void mumlib::Transport::sendSslAsync(uint8_t *buff, int length) {
 
     async_write(
             sslSocket,
-            boost::asio::buffer(asyncBuff, static_cast<size_t>(length)),
+            buffer(asyncBuff, static_cast<size_t>(length)),
             [this, asyncBuff](const boost::system::error_code &ec, size_t bytesTransferred) {
                 asyncBufferPool.free(asyncBuff);
                 //logger.warn("Sent %d B.", bytesTransferred);
@@ -537,14 +544,12 @@ void mumlib::Transport::sendControlMessage(MessageType type, google::protobuf::M
 }
 
 void mumlib::Transport::sendControlMessagePrivate(MessageType type, google::protobuf::Message &message) {
-
-
     const uint16_t type_network = htons(static_cast<uint16_t>(type));
 
-    const int size = message.ByteSize();
+    const size_t size = message.ByteSizeLong();
     const uint32_t size_network = htonl((uint32_t) size);
 
-    const int length = sizeof(type_network) + sizeof(size_network) + size;
+    const size_t length = sizeof(type_network) + sizeof(size_network) + size;
 
     uint8_t buff[MAX_UDP_LENGTH];
 
@@ -552,7 +557,10 @@ void mumlib::Transport::sendControlMessagePrivate(MessageType type, google::prot
 
     memcpy(buff + sizeof(type_network), &size_network, sizeof(size_network));
 
-    message.SerializeToArray(buff + sizeof(type_network) + sizeof(size_network), size);
+    if (!message.SerializeToArray(buff + sizeof(type_network) + sizeof(size_network), static_cast<int>(size))) {
+        logger.warn("Serializing control message failed!");
+        return;
+    }
 
     sendSsl(buff, length);
 }
@@ -563,12 +571,12 @@ void mumlib::Transport::throwTransportException(string message) {
     throw TransportException(std::move(message));
 }
 
-mumlib::SslContextHelper::SslContextHelper(ssl::context &ctx, std::string cert_file, std::string privkey_file) {
-    if ( cert_file.size() > 0 ) {
-        ctx.use_certificate_file(cert_file, ssl::context::file_format::pem);
+mumlib::SslContextHelper::SslContextHelper(ssl::context &ctx, std::string cert_file_path, std::string privkey_file_path) {
+    if ( !cert_file_path.empty() ) {
+        ctx.use_certificate_file(cert_file_path, ssl::context::file_format::pem);
     }
-    if ( privkey_file.size() > 0 ) {
-        ctx.use_private_key_file(privkey_file, ssl::context::file_format::pem);
+    if ( !privkey_file_path.empty() ) {
+        ctx.use_private_key_file(privkey_file_path, ssl::context::file_format::pem);
     }
 }
 
@@ -589,7 +597,7 @@ void mumlib::Transport::sendEncodedAudioPacket(uint8_t *buffer, int length) {
 
         const uint32_t netLength = htonl(static_cast<uint32_t>(length));
 
-        const int packet = sizeof(netUdptunnelType) + sizeof(netLength) + length;
+        const size_t packet = sizeof(netUdptunnelType) + sizeof(netLength) + length;
 
         uint8_t packetBuff[MAX_UDP_LENGTH];
 

--- a/src/mumlib.cpp
+++ b/src/mumlib.cpp
@@ -27,7 +27,7 @@ namespace mumlib {
         log4cpp::Category &logger = log4cpp::Category::getInstance("mumlib.Mumlib");
 
         bool externalIoService;
-        io_service &ioService;
+        io_context &ioService;
 
         Callback &callback;
 
@@ -43,13 +43,13 @@ namespace mumlib {
         std::vector<MumbleChannel> listMumbleChannel;
 
         _Mumlib_Private(Callback &callback, MumlibConfiguration &configuration)
-                : _Mumlib_Private(callback, *(new io_service()), configuration) {
+                : _Mumlib_Private(callback, *(new io_context()), configuration) {
             externalIoService = false;
         }
 
         _Mumlib_Private(
                 Callback &callback,
-                io_service &ioService,
+                io_context &ioService,
                 MumlibConfiguration &configuration)
                 : callback(callback),
                   ioService(ioService),
@@ -430,7 +430,7 @@ namespace mumlib {
         impl = new _Mumlib_Private(callback, conf);
     }
 
-    Mumlib::Mumlib(Callback &callback, io_service &ioService) {
+    Mumlib::Mumlib(Callback &callback, io_context &ioService) {
         MumlibConfiguration conf;
         impl = new _Mumlib_Private(callback, ioService, conf);
     }
@@ -438,7 +438,7 @@ namespace mumlib {
     Mumlib::Mumlib(Callback &callback, MumlibConfiguration &configuration)
             : impl(new _Mumlib_Private(callback, configuration)) { }
 
-    Mumlib::Mumlib(Callback &callback, io_service &ioService, MumlibConfiguration &configuration)
+    Mumlib::Mumlib(Callback &callback, io_context &ioService, MumlibConfiguration &configuration)
             : impl(new _Mumlib_Private(callback, ioService, configuration)) { }
 
     Mumlib::~Mumlib() {

--- a/src/mumlib.cpp
+++ b/src/mumlib.cpp
@@ -7,7 +7,6 @@
 #include "mumlib.hpp"
 
 #include <boost/asio.hpp>
-#include <boost/bind.hpp>
 #include <openssl/sha.h>
 #include <log4cpp/Category.hh>
 
@@ -18,6 +17,7 @@
 #endif
 
 using namespace std;
+using namespace std::placeholders;
 using namespace boost::asio;
 
 using namespace mumlib;
@@ -56,8 +56,8 @@ namespace mumlib {
                   externalIoService(true),
                   transport(
                           ioService,
-                          boost::bind(&_Mumlib_Private::processIncomingTcpMessage, this, _1, _2, _3),
-                          boost::bind(&_Mumlib_Private::processAudioPacket, this, _1, _2, _3),
+                          std::bind(&_Mumlib_Private::processIncomingTcpMessage, this, _1, _2, _3),
+                          std::bind(&_Mumlib_Private::processAudioPacket, this, _1, _2, _3),
                           false,
                           configuration.cert_file,
                           configuration.privkey_file),

--- a/src/mumlib.cpp
+++ b/src/mumlib.cpp
@@ -393,8 +393,8 @@ namespace mumlib {
         }
 
         bool isListUserContains(int sessionId) {
-            for(int i = 0; i < listMumbleUser.size(); i++)
-                if(listMumbleUser[i].sessionId == sessionId)
+            for(auto & user : listMumbleUser)
+                if(user.sessionId == sessionId)
                     return true;
             return false;
         }
@@ -409,8 +409,8 @@ namespace mumlib {
         }
 
         bool isListChannelContains(int channelId) {
-            for(int i = 0; i < listMumbleChannel.size(); i++)
-                if(listMumbleChannel[i].channelId == channelId)
+            for(auto & channel : listMumbleChannel)
+                if(channel.channelId == channelId)
                     return true;
             return false;
         }
@@ -513,8 +513,8 @@ namespace mumlib {
     }
 
     void Mumlib::joinChannel(string name) {
-        int channelId = Mumlib::getChannelIdBy(name);
-        Mumlib::joinChannel(channelId);
+        int channelId = getChannelIdBy(name);
+        joinChannel(channelId);
     }
 
     void Mumlib::sendVoiceTarget(int targetId, VoiceTargetType type, int id) {
@@ -598,7 +598,7 @@ namespace mumlib {
 
         SHA1((unsigned char*) val.c_str(), val.size(), digest);
         for(int i = 0; i < SHA_DIGEST_LENGTH; i++)
-            sprintf(&mdString[i*2], "%02x", (unsigned int) digest[i]);
+            snprintf(&mdString[i*2], 3, "%02x", (unsigned int) digest[i]);
 
         switch (field) {
             case UserState::COMMENT:
@@ -616,33 +616,33 @@ namespace mumlib {
     }
 
     int Mumlib::getChannelIdBy(string name) {
-        vector<mumlib::MumbleChannel> listMumbleChannel = impl->listMumbleChannel;
-        for(int i = 0; i < listMumbleChannel.size(); i++)
-            if(listMumbleChannel[i].name == name)
-                return listMumbleChannel[i].channelId;
+        const vector<MumbleChannel> listMumbleChannel = impl->listMumbleChannel;
+        for(auto & channel : listMumbleChannel)
+            if(channel.name == name)
+                return channel.channelId;
         return -1;
     }
 
     int Mumlib::getUserIdBy(string name) {
-        vector<mumlib::MumbleUser> listMumbleUser = impl->listMumbleUser;
-        for(int i = 0; i < listMumbleUser.size(); i++)
-            if(listMumbleUser[i].name == name)
-                return listMumbleUser[i].sessionId;
+        const vector<MumbleUser> listMumbleUser = impl->listMumbleUser;
+        for(auto & user : listMumbleUser)
+            if (user.name == name)
+                return user.sessionId;
         return -1;
     }
 
     bool Mumlib::isSessionIdValid(int sessionId) {
-        vector<mumlib::MumbleUser> listMumbleUser = impl->listMumbleUser;
-        for(int i = 0; i < listMumbleUser.size(); i++)
-            if(listMumbleUser[i].sessionId == sessionId)
+        vector<MumbleUser> listMumbleUser = impl->listMumbleUser;
+        for(const auto & user : listMumbleUser)
+            if (user.sessionId == sessionId)
                 return true;
         return false;
     }
 
     bool Mumlib::isChannelIdValid(int channelId) {
-        vector<mumlib::MumbleChannel> listMumbleChannel = impl->listMumbleChannel;
-        for(int i = 0; i < listMumbleChannel.size(); i++)
-            if(listMumbleChannel[i].channelId == channelId)
+        vector<MumbleChannel> listMumbleChannel = impl->listMumbleChannel;
+        for(const auto & channel : listMumbleChannel)
+            if (channel.channelId == channelId)
                 return true;
         return false;
     }


### PR DESCRIPTION
Hi! I just tried building mumsi on a more recent version of alpine (3.23) and encountered two problems, which this PR would fix. I can't say anything about backwards compatibility or minimum required versions because I just hacked on this until it worked.

1) CMake 4.0 supports 3.5 files at minimum and errors out on older versions. Bump it to 3.5, which seems to work fine.
2) Protobuf generates code that depends on Abseil, where some of that requires C++17.
